### PR TITLE
Fixing account bugs

### DIFF
--- a/controller.rb
+++ b/controller.rb
@@ -69,7 +69,7 @@ class BankFlow
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin)
       Dialog::account_prompt 
-      account_info
+      @account_id_array = Display::account_info(@acct_list)
       @acct_num = Dialog::pick_your_account
       if !@account_id_array.include?(@acct_num)
         Dialog::fixnum_error
@@ -80,16 +80,14 @@ class BankFlow
         puts @account.return_balance(@cust_id)
       end
       account_choice
-
     when "deposit"
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin) 
       Dialog::account_prompt 
-      account_info
+      Display::account_info(@acct_list)
       @acct_num = Dialog::pick_your_account
       if !@account_id_array.include?(@acct_num)
         Dialog::fixnum_error
-
       else
         account = bank.load_account(@acct_num)
         amount = -1
@@ -100,12 +98,11 @@ class BankFlow
         account.save_to_db
       end
       account_choice
-
     when "withdraw"
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin) 
       Dialog::account_prompt 
-      account_info
+      Display::account_info(@acct_list)
       @acct_num = Dialog::pick_your_account
       if !@account_id_array.include?(@acct_num)
         Dialog::fixnum_error
@@ -118,22 +115,12 @@ class BankFlow
         account.withdraw(amount)
         account.save_to_db
       end
-      account_choice
-      
+      account_choice 
     when "end"
       Dialog::goodbye_cust
-
     else
       Dialog::wrong_entry
       account_choice
-    end
-  end
-
-  def account_info
-    @account_id_array = []
-    @acct_list.each do |a|
-    print a["account_id"]
-    @account_id_array.push(a["account_id"])
     end
   end
 end

--- a/controller.rb
+++ b/controller.rb
@@ -64,8 +64,8 @@ class BankFlow
 
   def account_choice # Asks user if they want to deposit/withdraw, view current balance, or end their session.
     action = Dialog::how_can_we_help_you
-
-    if action == "balance"
+    case action
+    when "balance"
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin)
       Dialog::account_prompt 
@@ -81,7 +81,7 @@ class BankFlow
       end
       account_choice
 
-    elsif action == "deposit"
+    when "deposit"
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin) 
       Dialog::account_prompt 
@@ -92,13 +92,16 @@ class BankFlow
 
       else
         account = bank.load_account(@acct_num)
-        amount = Dialog::deposit_amount
+        amount = -1
+        while amount < 0
+          amount = Dialog::deposit_amount
+        end
         account.deposit(amount)
         account.save_to_db
       end
       account_choice
 
-    elsif action == "withdraw"
+    when "withdraw"
       Dialog::space
       @acct_list = @bank.customer_accounts(@name, @pin) 
       Dialog::account_prompt 
@@ -106,16 +109,18 @@ class BankFlow
       @acct_num = Dialog::pick_your_account
       if !@account_id_array.include?(@acct_num)
         Dialog::fixnum_error
-
       else
         account = bank.load_account(@acct_num)
-        amount = Dialog::withdraw_amount
+        amount = -1
+        while amount < 0
+          amount = Dialog::withdraw_amount
+        end
         account.withdraw(amount)
         account.save_to_db
       end
       account_choice
       
-    elsif action == "end"
+    when "end"
       Dialog::goodbye_cust
 
     else

--- a/controller.rb
+++ b/controller.rb
@@ -62,60 +62,61 @@ class BankFlow
     end
   end
 
+  def show_accounts
+    Dialog::space
+    @acct_list = @bank.customer_accounts(@name, @pin)
+    Dialog::account_prompt
+    @account_id_array = Display::account_info(@acct_list)
+  end
+
+  def do_dep_with_and_bal
+    @acct_num = Dialog::pick_your_account
+    if !@account_id_array.include?(@acct_num)
+      Dialog::fixnum_error
+    else
+      @account = bank.load_account(@acct_num)
+      yield
+    end
+  end
+
+  def do_balance
+    @cust_id = bank.find_customer_id(@name, @pin)
+    puts @account.return_balance(@cust_id)
+  end
+
+  def do_deposit
+    amount = -1
+    while amount < 0
+      amount = Dialog::deposit_amount
+    end
+    @account.deposit(amount)
+    @account.save_to_db
+  end
+
+  def do_withdraw
+    amount = -1
+    while amount < 0
+      amount = Dialog::withdraw_amount
+    end
+    @account.withdraw(amount)
+    @account.save_to_db
+  end
+
   def account_choice # Asks user if they want to deposit/withdraw, view current balance, or end their session.
     action = Dialog::how_can_we_help_you
     case action
     when "balance"
-      Dialog::space
-      @acct_list = @bank.customer_accounts(@name, @pin)
-      Dialog::account_prompt 
-      @account_id_array = Display::account_info(@acct_list)
-      @acct_num = Dialog::pick_your_account
-      if !@account_id_array.include?(@acct_num)
-        Dialog::fixnum_error
-
-      else
-        @account = bank.load_account(@acct_num)
-        @cust_id = bank.find_customer_id(@name, @pin)
-        puts @account.return_balance(@cust_id)
-      end
+      show_accounts
+      do_dep_with_and_bal {do_balance}
       account_choice
     when "deposit"
-      Dialog::space
-      @acct_list = @bank.customer_accounts(@name, @pin) 
-      Dialog::account_prompt 
-      Display::account_info(@acct_list)
-      @acct_num = Dialog::pick_your_account
-      if !@account_id_array.include?(@acct_num)
-        Dialog::fixnum_error
-      else
-        account = bank.load_account(@acct_num)
-        amount = -1
-        while amount < 0
-          amount = Dialog::deposit_amount
-        end
-        account.deposit(amount)
-        account.save_to_db
-      end
+      show_accounts
+      do_dep_with_and_bal {do_deposit}
       account_choice
     when "withdraw"
-      Dialog::space
-      @acct_list = @bank.customer_accounts(@name, @pin) 
-      Dialog::account_prompt 
-      Display::account_info(@acct_list)
-      @acct_num = Dialog::pick_your_account
-      if !@account_id_array.include?(@acct_num)
-        Dialog::fixnum_error
-      else
-        account = bank.load_account(@acct_num)
-        amount = -1
-        while amount < 0
-          amount = Dialog::withdraw_amount
-        end
-        account.withdraw(amount)
-        account.save_to_db
-      end
-      account_choice 
+      show_accounts
+      do_dep_with_and_bal {do_withdraw}
+      account_choice
     when "end"
       Dialog::goodbye_cust
     else

--- a/model.rb
+++ b/model.rb
@@ -61,8 +61,8 @@ class Bank
   # Returns true if name and pin match are found or false if not found; table 
   # parameter should be either "customers" or "managers"
   def verify_pin(name, pin, table)
-    db.execute("SELECT 1 FROM #{table} WHERE name = ? AND pin = ?", 
-      name, pin).length > 0
+    db.execute("SELECT 1 FROM #{table} WHERE LOWER(name) = ? AND pin = ?", 
+      name.downcase, pin).length > 0
   end
 
   # Returns list of all bank accounts as an array of hashes. Requires manager 
@@ -75,14 +75,14 @@ class Bank
   # Returns true if name exists in given table; table parameter should be either
   # "customers" or "managers"
   def name_exists?(name, table)
-    db.execute("SELECT 1 FROM #{table} WHERE name = ?", 
-      name).length > 0
+    db.execute("SELECT 1 FROM #{table} WHERE LOWER(name) = ?", 
+      name.downcase).length > 0
   end
 
   # Returns customer_id of customer found with name and pin
   def find_customer_id(name, pin)
-    customer = db.execute("SELECT * FROM customers WHERE name = ? AND pin = ?", 
-      name, pin)
+    customer = db.execute("SELECT * FROM customers WHERE LOWER(name) = ? AND pin = ?", 
+      name.downcase, pin)
     return customer[0]["customer_id"]
   end
 

--- a/view.rb
+++ b/view.rb
@@ -21,17 +21,17 @@ module Dialog
   def self.account_name # this should be the dialog around initializing your bank account. You give your account name.  
     print "\nPlease enter your the name you wish to associate with the
      account: "
-    gets.chomp.downcase
+    gets.chomp
   end
 
   def self.signin_name
     print "\nPlease enter your account name: "
-    gets.chomp.downcase
+    gets.chomp
   end
 
   def self.signin_pin
     print "\nPlease enter your account pin: "
-    gets.chomp.downcase.to_i
+    gets.chomp.to_i
   end
 
   def self.existing_account_error
@@ -53,8 +53,9 @@ module Dialog
   end
 
   def self.pick_your_account
-    print "\n\n\nYour account number is displayed above. Please enter your account number: "
-    gets.chomp.downcase.to_i
+    print "\n\n\nYour list of accounts is displayed above. Please select an " +
+    "account by entering its account number: "
+    gets.chomp.to_i
   end 
   
   def self.positive_number_warning
@@ -64,18 +65,18 @@ module Dialog
   def self.deposit_amount # Asks for amount you would like to deposit
     positive_number_warning
     print "\nPlease enter the amount you would like to deposit: "
-    gets.chomp.downcase.to_f
+    gets.chomp.to_f
   end
 
   def self.withdraw_amount # Asks for amount you would like to deposit
     positive_number_warning
     print "\nPlease enter the amount you would like to withdraw: "
-    gets.chomp.downcase.to_f
+    gets.chomp.to_f
   end
 
   def self.enter_pin  # Asks you to enter your PIN number.
     print "\nPlease enter your unique PIN number: "
-    gets.chomp.downcase.to_i
+    gets.chomp.to_i
   end
 
   def self.pin_error_message # Should throw an error message when user print in incorrect password.
@@ -87,10 +88,24 @@ module Dialog
   end
 
   def self.wrong_username_or_pin
-    print "\nYou have either entered an incorrect name or PIN. Please try again.\n"
+    print "\nYou have either entered an incorrect name or PIN. Please try again"
+    + ",\n"
   end
 
   def self.fixnum_error
-    print "\nIncorrect entry. Your account number should be a number. Please enter only that number.\n"
+    print "\nIncorrect entry. Your account number should be a number. Please " +
+    "enter only that number.\n"
+  end
+end
+
+module Display
+  def self.account_info(acct_list)
+    account_id_array = []
+    acct_list.each do |a|
+      print 'Account #' + a["account_id"].to_s + "  -----  " + "Balance: " +
+      a["balance"].to_s
+      account_id_array.push(a["account_id"])
+    end
+    account_id_array
   end
 end

--- a/view.rb
+++ b/view.rb
@@ -89,7 +89,7 @@ module Dialog
 
   def self.wrong_username_or_pin
     print "\nYou have either entered an incorrect name or PIN. Please try again"
-    + ",\n"
+    print ",\n"
   end
 
   def self.fixnum_error

--- a/view.rb
+++ b/view.rb
@@ -102,6 +102,7 @@ module Display
   def self.account_info(acct_list)
     account_id_array = []
     acct_list.each do |a|
+      print "\n"
       print 'Account #' + a["account_id"].to_s + "  -----  " + "Balance: " +
       a["balance"].to_s
       account_id_array.push(a["account_id"])

--- a/view.rb
+++ b/view.rb
@@ -19,7 +19,8 @@ module Dialog
   end
 
   def self.account_name # this should be the dialog around initializing your bank account. You give your account name.  
-    print "\nPlease enter your the name you wish to associate with the account: "
+    print "\nPlease enter your the name you wish to associate with the
+     account: "
     gets.chomp.downcase
   end
 
@@ -37,7 +38,7 @@ module Dialog
     print "\n Our records inticate that you already have an account with us. Please sign in to your account.\n"
   end
 
-  def self.how_can_we_help_you # Dialog around asking user to enter their choice.
+  def self.how_can_we_help_you # Dialog asking user to enter their choice.
     print "\nHow can we help you? Would you like to 'deposit' or 'withdraw' to/from your account, view your current 'balance', or 'end' your session?"
     print "\n\n(Please enter 'deposit', 'withdraw', 'balance', or 'end'): "
     gets.chomp.downcase 
@@ -56,12 +57,18 @@ module Dialog
     gets.chomp.downcase.to_i
   end 
   
+  def self.positive_number_warning
+    puts "\nEntered amount must be a positive number."
+  end
+
   def self.deposit_amount # Asks for amount you would like to deposit
+    positive_number_warning
     print "\nPlease enter the amount you would like to deposit: "
     gets.chomp.downcase.to_f
   end
 
   def self.withdraw_amount # Asks for amount you would like to deposit
+    positive_number_warning
     print "\nPlease enter the amount you would like to withdraw: "
     gets.chomp.downcase.to_f
   end


### PR DESCRIPTION
In this merge we have an improved account number display that makes it more clear what to enter and displays the balance for each account to help differentiate them. Mind you, there is still no way to create more than one account for a customer. There is also enforcement of only positive numbers coming into the deposit and withdraw methods. Finally, I made it possible to have a name with uppercase letters without losing the ability to look up that name in lowercase.

Resolves issues #11, #12, and #13 
