### PR TITLE
Added ability to make and find managers much like customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ INSTRUCTIONS:
 
     1. Open your command line 
     2. Enter the following command into the command line: ruby controller.rb
-    3. Follow in instructions within the command line.
+    3. Follow the instructions within the command line.
     4. Enjoy!

--- a/model.rb
+++ b/model.rb
@@ -16,7 +16,8 @@ class Bank
     db.execute("PRAGMA foreign_keys = ON")
     accounts_table_exists = db.execute("SELECT 1 FROM sqlite_master WHERE 
       type='table' AND name= ?", "accounts").length > 0
-    managers_exist = db.execute("SELECT * FROM managers").length > 0
+    managers_exist = db.execute("SELECT 1 FROM sqlite_master WHERE 
+      type='table' AND name= ?", "managers").length > 0
     unless accounts_table_exists
       create_customers_table
       create_accounts_table


### PR DESCRIPTION
I tried to make interacting with managers as similar as possible to interacting with customers from a programming standpoint.

`initialize_database` will now add a manager if none exist with username `admin` and pin `1111`. There is a Manager class which inherits from Customer, and just like with Customer you can get a new instance of it returned to you to work with by using `load_manager(id)`. You can find the `id` of a manager similarly to a customer by using `find_manager_id(name, pin)` which will return that corresponding `id`. Similarly to a `Customer` instance, when creating a new manager with a `Manager` instance, you can do `manager_instance.add_to_db` to then permanently save that manager into the the managers table. You can use `account_list(name, pin)` to return to you a list of all accounts at the bank from all customers. I don't have this written so that a manger can have accounts directly associated with their manager account. I figured it maybe made more sense that if a manager wanted an account, they could open a customer account. Let me know if you have any concerns.
